### PR TITLE
Update ZCA-Permissions.json - kms

### DIFF
--- a/ZCA-Permissions.json
+++ b/ZCA-Permissions.json
@@ -68,9 +68,16 @@
                 "iam:PassRole",
                 "cloudtrail:DescribeTrails",
                 "cloudtrail:GetTrailStatus",
-                "cloudtrail:LookupEvents"
+                "cloudtrail:LookupEvents",
+				"kms:Encrypt",
+                "kms:Decrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+                "kms:DescribeKey",
+                "kms:CreateGrant",
+                "kms:ListAliases"
             ],
             "Resource": "*"
-        }
+        },
     ]
 }


### PR DESCRIPTION
Include permissions to allow failback of encrypted volumes managed by AWS KMS. Verify with PO/PM/Support before commit.